### PR TITLE
Fixed Content-Type json UTF-8

### DIFF
--- a/src/Request.php
+++ b/src/Request.php
@@ -105,7 +105,7 @@ class Request
         $param = explode("=", $chunk);
         $data[$param[0]] = $param[1];
       }
-    } else if (Headers::get('Content-Type') !== 'application/json' && strpos(Headers::get('Content-Type'), "multipart/form-data") !== 0) {
+    } else if (strpos(Headers::get('Content-Type'), "application/json") !== 0 && strpos(Headers::get('Content-Type'), "multipart/form-data") !== 0) {
       $safeData = false;
       $data = [$data];
     } else {


### PR DESCRIPTION
If Content-Type is 'application/json; charset=UTF-8' then it doesn't recognize it as json.

<!--
	Please only send a pull request to branches which are currently supported: https://leafphp.dev/community/contributing.html#pull-request-guidelines

	Pull requests without a descriptive title, thorough description, or tests will be closed.
-->

## Description

<!--
	Describe your changes in detail. In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->

## Related Issue

<!-- If suggesting a new feature or change, please discuss it in an issue first -->
<!-- If fixing a bug, there should be an issue describing it with steps to reproduce -->