### PR TITLE
Make Headers::get case insensitive (fix #11)

### DIFF
--- a/src/Headers.php
+++ b/src/Headers.php
@@ -64,7 +64,7 @@ class Headers
      */
     public static function get($params, bool $safeOutput = false)
     {
-        if (is_string($params)) return self::all($safeOutput)[$params] ?? null;
+        if (is_string($params)) return array_change_key_case(self::all($safeOutput), CASE_LOWER)[strtolower($params)] ?? null;
 
         $data = [];
         foreach ($params as $param) {


### PR DESCRIPTION
## Description

Basically changed

```
if (is_string($params)) return self::all($safeOutput)[$params] ?? null;
```
to

```
if (is_string($params)) return array_change_key_case(self::all($safeOutput), CASE_LOWER)[strtolower($params)] ?? null;
```

Because if a header is set like this: `Content-type: application/json`

```
Headers::get('Content-Type');  // null
Headers::get('Content-type');  // 'application/json'
```

`Request::get` method gets the `Content-Type` header at line 108 and passes it as the first parameter to `strpos`. Because the `Headers::get` function is currently case sensitive, the case of the header must be an exact match or else it will return `null` and the following error is caused:

```
Passing null to parameter #1 ($haystack) of type string is deprecated
```

**Note:** Headers are meant to be case insensitive so this will not hurt the user experience or be a breaking change.
<!--
	Describe your changes in detail. In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->

## Related Issue

#11 