### PR TITLE
fix: isAjax header correction

### DIFF
--- a/src/Request.php
+++ b/src/Request.php
@@ -67,15 +67,7 @@ class Request
      */
     public static function isAjax(): bool
     {
-        if (static::params('isajax')) {
-            return true;
-        }
-
-        if (Headers::get('X_REQUESTED_WITH') && Headers::get('X_REQUESTED_WITH') === 'XMLHttpRequest') {
-            return true;
-        }
-
-        return false;
+        return !!static::params('isajax') || Headers::get('X-Requested-With') === 'XMLHttpRequest';
     }
 
     /**


### PR DESCRIPTION


<!--
	Please only send a pull request to branches which are currently supported: https://leafphp.dev/community/contributing.html#pull-request-guidelines

	Pull requests without a descriptive title, thorough description, or tests will be closed.
-->

## Description
The `Request::isAjax()` method attempts to retrieve an HTTP header via `Headers::get()` by passing a header name as is formatted in `$_SERVER`.  This does not work as `Headers::all()` returns the headers with keys as passed in the actual HTTP request.  The primary issue being the usage of underscores (X_REQUESTED_WITH) versus hyphens/dashes (X-REQUESTED-WITH).

I took the opportunity to try and cleanup/optimize the method as well since it is so short.
<!--
	Describe your changes in detail. In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->

## Related Issue
N/A
<!-- If suggesting a new feature or change, please discuss it in an issue first -->
<!-- If fixing a bug, there should be an issue describing it with steps to reproduce -->