### PR TITLE
Fix Content-type and Content-length formatting error

### DIFF
--- a/src/Headers.php
+++ b/src/Headers.php
@@ -171,8 +171,14 @@ class Headers
 
         $headers = [];
         foreach ($_SERVER as $name => $value) {
-            if ((substr($name, 0, 5) == 'HTTP_') || ($name == 'CONTENT_TYPE') || ($name == 'CONTENT_LENGTH')) {
+            if ((substr($name, 0, 5) == 'HTTP_')) {
                 $headers[str_replace([' ', 'Http'], ['-', 'HTTP'], ucwords(strtolower(str_replace('_', ' ', substr($name, 5)))))] = $value;
+            }
+            else if ($name == 'CONTENT_TYPE') {
+                $headers['Content-Type'] = $value;
+            }
+            else if ($name == 'CONTENT_LENGTH') {
+                $headers['Content-Length'] = $value;
             }
         }
         return $headers;


### PR DESCRIPTION
## Description

When `getallheaders()` is unavailable headers are obtained by formatting `$_SERVER['HTTP_...']` keys to the standard header name format. However `CONTENT_TYPE` and `CONTENT_LENGTH` are formatted the same way as the `HTTP_...` variables, ie. by removing the first 5 characters. Line no 175.
![image](https://github.com/leafsphp/http/assets/122541423/26eea068-e8eb-4c24-a06b-506829ef494e)

`Content-type` is formatted as `Nt-type` after the first 5 characters are removed. This can be easily fixed by adding a condition for these keys.
```
            if ((substr($name, 0, 5) == 'HTTP_')) {
                $headers[str_replace([' ', 'Http'], ['-', 'HTTP'], ucwords(strtolower(str_replace('_', ' ', substr($name, 5)))))] = $value;
            }
            else if ($name == 'CONTENT_TYPE') {
                $headers['Content-Type'] = $value;
            }
            else if ($name == 'CONTENT_LENGTH') {
                $headers['Content-Length'] = $value;
            }
```