### PR TITLE
Add `store` and `storeAs` methods to the Request class

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -33,6 +33,7 @@
   "prefer-stable": true,
   "require": {
     "leafs/anchor": "*",
-    "leafs/form": "*"
+    "leafs/form": "*",
+    "leafs/fs": "*"
   }
 }


### PR DESCRIPTION
Description
-----------

This pull request introduces two new methods to the Request class: `store` and `storeAs`. These methods enhance file upload capabilities and provide more control over the file handling process.

1.  **`store` Method:**
    
    *   **Purpose:** This method stores a file from the request to a specified directory.
    *   **Parameters:**
        *   `string $key`: The name of the file input in the request.
        *   `string $destination`: The directory where the file should be stored.
        *   `array $configs`: Optional configurations such as `max_file_size`, `file_type`, and `extensions`.
    *   **Returns:** An object containing `status`, `path`, and `error` message.
    *   **Benefit:** Allows for validating file extensions and size limits, providing more granular control over file uploads.
2.  **`storeAs` Method:**
    
    *   **Purpose:** This method stores a file from the request with a specific name.
    *   **Parameters:**
        *   `string $key`: The name of the file input in the request.
        *   `string $destination`: The directory where the file should be stored.
        *   `string $filename`: The name to give the stored file.
        *   `array $configs`: Optional configurations such as `max_file_size`, `file_type`, and `extensions`.
    *   **Returns:** An object containing `status`, `path`, and `error` message.
    *   **Benefit:** Provides the ability to rename files upon upload, in addition to validating extensions and size limits.

These enhancements provide users with more flexibility and control over file uploads, ensuring that only files meeting specific criteria are accepted.

Notes
-----

1.  The FS package currently supports general file type validation (e.g., image, video). The new `extensions` validation allows users to restrict file uploads to a specific set of extensions, offering finer control over file types.
2.  Both methods ensure cross compatibility with the $configs rules for the FS::uploadFile method

Usage Examples
--------------

Assuming that the enduser has mvc-core package installed and running

### Example for `store` Method

```php
# without options
request::store('file', '/uploads/directory')

# with options
request::store('file', '/uploads/directory', [
    'extensions' => 'extensions' => ['jpg', 'jpeg', 'png', 'gif']
]

// output: FsInstance::$uploadInfo;
```

### Example for `storeAs` Method

```php
# without options
request::storeAs('file', '/uploads/directory', 'myNewName')

# with options
request::storeAs('file', '/uploads/directory', 'myNewName', [
    'file_type' => 'image',
    'max_file_size' => 10
]

// output: FsInstance::$uploadInfo;
```