### PR TITLE
add custom responses (fix #21)

### DIFF
--- a/src/Response.php
+++ b/src/Response.php
@@ -55,6 +55,21 @@ class Response
     }
 
     /**
+     * Output any text
+     * 
+     * @param string $data The data to output
+     * @param int $code The response status code
+     */
+    public function echo(string $data, int $code = 200)
+    {
+        $this->status = $code;
+        $this->headers['Content-Type'] ??= 'text/plain';
+        $this->content = $data;
+
+        $this->send();
+    }
+
+    /**
      * Output plain text
      *
      * @param mixed $data The data to output

--- a/src/Response.php
+++ b/src/Response.php
@@ -98,6 +98,21 @@ class Response
 
         $this->send();
     }
+    
+    /**
+     * Output js script
+     * 
+     * @param string $data The data to output
+     * @param int $code The response status code
+     */
+    public function js(string $data, int $code = 200)
+    {
+        $this->status = $code;
+        $this->headers['Content-Type'] = 'text/javascript';
+        $this->content = $data;
+
+        $this->send();
+    }
 
     /**
      * Output json encoded data with an HTTP code/message


### PR DESCRIPTION
<!--
	Please only send a pull request to branches which are currently supported: https://leafphp.dev/community/contributing.html#pull-request-guidelines

	Pull requests without a descriptive title, thorough description, or tests will be closed.
-->

## What kind of change does this PR introduce? (pls check at least one)

<!-- (Update "[ ]" to "[x]" to check a box) -->

- [ ] Bugfix
- [x] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe below

## Description

<!--
	Describe your changes in detail. In addition, please describe the benefit to end users; how it makes building easier, etc.
	You can link to issues here.
-->
As described in #21 there was no way to create custom `Content-Type` responses. (I needed it for a js response)

I added 
```js
    /**
     * Output any text
     * 
     * @param string $data The data to output
     * @param int $code The response status code
     */
    public function echo(string $data, int $code = 200)
    {
        $this->status = $code;
        $this->headers['Content-Type'] ??= 'text/plain';
        $this->content = $data;

        $this->send();
    }
```
to add custom content type functionality with a fallback to `text/plain`

Then I added a "js()" function with `Content-Type` of `text/javascript` to fit my exact need (might not be super common).

## Does this PR introduce a breaking change? (check one)

<!-- We prefer to avoid breaking changes. We will only accept PRs with breaking changes if they have been discussed in an issue first -->

- [ ] Yes
- [x] No

## Related Issue

<!-- If suggesting a new feature or change, please discuss it in an issue first -->
#21 
<!-- If fixing a bug, there should be an issue describing it with steps to reproduce -->