### PR TITLE
Fixed issue: 'Fatal error with unofficial http status codes'

### DIFF
--- a/src/Response.php
+++ b/src/Response.php
@@ -451,7 +451,7 @@ EOT;
         Headers::set($this->headers);
 
         // status
-        header(sprintf('%s %s %s', $this->httpVersion(), $this->status, Status::$statusTexts[$this->status]), true, $this->status);
+        header(sprintf('%s %s %s', $this->httpVersion(), $this->status, Status::$statusTexts[$this->status] ?? ''), true, $this->status);
 
         return $this;
     }


### PR DESCRIPTION
<!--
	Please only send a pull request to branches which are currently supported: https://leafphp.dev/community/contributing.html#pull-request-guidelines

	Pull requests without a descriptive title, thorough description, or tests will be closed.
-->

## What kind of change does this PR introduce? (pls check at least one)

<!-- (Update "[ ]" to "[x]" to check a box) -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe below

## Description
When using unofficial status codes, a fatal error is returned as described in the issue raised by @patrickvuarnoz. In the event the custom status code is not yet registered in ```$statusTexts```, this error will be returned. However, as suggested by @patrickvuarnoz, updating line number ```454``` from:

> ```header(sprintf('%s %s %s', $this->httpVersion(), $this->status, Status::$statusTexts[$this->status]), true, $this->status);```

to:

> ```header(sprintf('%s %s %s', $this->httpVersion(), $this->status, Status::$statusTexts[$this->status] ?? ''), true, $this->status);```

.. returns an empty string just in case the custom status code is not defined.

<!--
	Describe your changes in detail. In addition, please describe the benefit to end users; how it makes building easier, etc.
	You can link to issues here.
-->

## Does this PR introduce a breaking change? (check one)

<!-- We prefer to avoid breaking changes. We will only accept PRs with breaking changes if they have been discussed in an issue first -->

- [ ] Yes
- [x] No

## Related Issue

<!-- If suggesting a new feature or change, please discuss it in an issue first -->

<!-- If fixing a bug, there should be an issue describing it with steps to reproduce -->
