### PR TITLE
getUserAgent() doesn't properly get the header because of conversion.

### DIFF
--- a/src/Request.php
+++ b/src/Request.php
@@ -725,7 +725,7 @@ class Request
      */
     public static function getUserAgent(): ?string
     {
-        return Headers::get('HTTP_USER_AGENT');
+        return Headers::get('USER-AGENT');
     }
 
     /**


### PR DESCRIPTION
Hi guys!👋

## What kind of change does this PR introduce?

<!-- (Update "[ ]" to "[x]" to check a box) -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe below

## Description

`request()->getUserAgent()` doesn't return the user agent because it can't find the proper header name of it.

### The code flow is the following:

getUserAgent()
→ Headers::get('HTTP_USER_AGENT')
→ self::all()
→ findHeaders()
→ transforms 'HTTP_USER_AGENT' to 'User-Agent'
→ lookup fails because of the wrong key.

### Fixing it

Inside Requests.php -> Request Class -> getUserAgent() Method;
We can simply "return Headers::get('USER-AGENT');" instead of "Headers::get('HTTP_USER_AGENT');.

## Does this PR introduce a breaking change?

- [ ] Yes
- [X] No

## Related Issue

<!-- If suggesting a new feature or change, please discuss it in an issue first -->

<!-- If fixing a bug, there should be an issue describing it with steps to reproduce -->
